### PR TITLE
Replace `ds9scan` by `ds9get`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,16 +14,21 @@ the `SAOImageDS9.` prefix.
 - `ds9get` replaces `SAOImageDS9.get` to send an XPA *get* request to SAOImage/DS9.
 - `ds9set` replaces `SAOImageDS9.set` to send an XPA *set* request to SAOImage/DS9.
 
-As was the case for `SAOImageDS9.get`, method `ds9get` may convert the binary data
-associated with the answer to a variety of result types but no longer *scan* or *parse*
-the answer interpreted as an ASCII string. This is the job of the new method `ds9scan`.
-This is to favor type-stable results and to more clearly indicate how is interpreted the
-answer of an XPA *get* request. For example, to retrieve a vector of bytes with the pixel
-data (there are of course better ways to retrieve the pixels as an array):
+Method `ds9get` is nearly equivalent to `SAOImageDS9.get`. `r = ds9get(T, cmd)` yields a
+result `r` of type `T` from the *get* command `cmd`. If `T` is `eltype(XPA.Reply)`, `r` is
+the bare un-processed answer and properties `r.data`, `r.message`, `r.has_message`,
+`r.has_error` etc. may be used to deal with it. For all other types `T`, the answer is
+interpreted as an ASCII string, the so-called *textual answer*. If `T` is `String`, `r` is
+the textual answer unchanged. If `T` is a *tuple or vector type*, the textual answer is
+split in words which are parsed according to the types of the entries of `T`. If `T` is a
+*scalar type*, `r` is a value of type `T` parsed in the textual answer. Without `T`
+specified, `ds9get(cmd)` is equivalent to `chomp(ds9get(String, cmd))`.
+
+As a first example, to retrieve raw answer data or un-processed answer:
 
 ```julia
-SAOImageDS9.get(Vector{UInt8}, "array") # previously
-ds9get(Vector{UInt8}, "array") # now
+SAOImageDS9.get(Vector{UInt8}, "array") # previously, answer data as bytes
+ds9get(eltype(XPA.Reply), "array") # now, fully un-processed answer
 ```
 
 As another example, to deal with an answer that is an ASCII string:
@@ -34,12 +39,9 @@ SAOImageDS9.get(String, "fits size") # previously
 ds9get(String, "fits size") # now
 # Scan the answer interpreted as an ASCII string:
 SAOImageDS9.get(Tuple{Vararg{Int}}, "fits size") # previously, not type stable
-ds9scan(NTuple{2,Int}, "fits size") # now, type-stable but require to know N
-ds9scan(Vector{Int}, "fits size") # now, type-stable
+ds9get(NTuple{2,Int}, "fits size") # now, type-stable but require to know N
+ds9get(Vector{Int}, "fits size") # now, type-stable
 ```
-
-Note that `ds9get(Vector{Int}, "fits size")` would have returned the bytes of the answer
-interpreted as a vector of `Int`s.
 
 ### Added or changed
 
@@ -55,7 +57,6 @@ Exported public methods:
 - `ds9launch` to launch the default SAOImage/DS9 application.
 - `ds9message` to display a simple message dialog in SAOImage/DS9.
 - `ds9quit` to make SAOImage/DS9 to quit.
-- `ds9scan` to send an XPA *get* request to SAOImage/DS9 and scan the textual result.
 - `ds9set` to send an XPA *set* request to SAOImage/DS9.
 - `ds9wcs` to get the FITS cards defining the WCS transform in SAOImage/DS9.
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,3 @@ SAOImageDS9 = "dbce9b26-8eb4-4825-964b-d4940cf8daff"
 
 [compat]
 Documenter = "1"
-
-[sources.SAOImageDS9]
-path = ".."

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,13 +1,18 @@
-using Documenter
+DEPLOYDOCS = (get(ENV, "CI", nothing) == "true")
+push!(LOAD_PATH, "../src/")
 using SAOImageDS9
+using Documenter
+using Documenter.Remotes: GitHub
 
 include("pages.jl")
 
-makedocs(
+makedocs(;
     modules = [SAOImageDS9],
     sitename = "SAOImageDS9.jl",
+    repo = GitHub("JuliaAstro/SAOImageDS9.jl"),
     format = Documenter.HTML(
         canonical = "https://juliaastro.org/SAOImageDS9/stable/",
+        prettyurls = DEPLOYDOCS,
     ),
     authors = "Éric Thiébaut and contributors",
     pages = pages,
@@ -15,8 +20,10 @@ makedocs(
     checkdocs = :export,
 )
 
-deploydocs(
-    repo = "github.com/JuliaAstro/SAOImageDS9.jl.git",
-    push_preview = true,
-    versions = ["stable" => "v^", "v#.#"], # Restrict to minor releases
-)
+if DEPLOYDOCS
+    deploydocs(
+        repo = "github.com/JuliaAstro/SAOImageDS9.jl.git",
+        push_preview = true,
+        versions = ["stable" => "v^", "v#.#"], # Restrict to minor releases
+    )
+end

--- a/docs/makedocs
+++ b/docs/makedocs
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+dir=$(dirname "$0")
+cd "$dir/.."
+test -e Manifest.toml || julia --startup-file=no --project=docs/ -e \
+    'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
+julia --startup-file=no --project=docs/ docs/make.jl

--- a/docs/src/connect.md
+++ b/docs/src/connect.md
@@ -1,12 +1,12 @@
 # Connection to a specific server
 
-When `SAOImageDS9.connect()` is called without any argument, all subsequent
+When `ds9connect()` is called without any argument, all subsequent
 requests will be sent to the first SAOImage/DS9 instance found by the XPA name
 server.  To send further requests to a specific SAOImage/DS9 server, you may
 do:
 
 ```julia
-SAOImageDS9.connect(apt) -> ident
+ds9connect(apt) -> ident
 ```
 
 where `apt` is a string identifying a specific XPA access point.  The returned
@@ -17,7 +17,7 @@ a template of the form `class:name` like `"DS9:*"` which corresponds to any
 server of the class `"DS9"`.  Note that `name` is the argument of the `-title`
 option when SAOImage/DS9 is launched.  See [XPA
 Template](http://hea-www.harvard.edu/RD/xpa/template.html) for a complete
-description.  When `SAOImageDS9.connect()` is called with no arguments or with
+description.  When `ds9connect()` is called with no arguments or with
 a template containing wild characters, it automatically connects to the first
 access point matching the template (`"DS9.*"` by default) with a warning if no
 access points, or if more than one access point are found.
@@ -25,7 +25,7 @@ access points, or if more than one access point are found.
 To retrieve the identifier of the current access point to SAOImage/DS9, you may call:
 
 ```julia
-SAOImageDS9.accesspoint()
+ds9accesspoint()
 ```
 
 which yields an empty string if there are no current connection.
@@ -34,9 +34,9 @@ Remember that all requests are sent to a given access point, but you may switch
 between SAOImage/DS9 servers.  For instance:
 
 ```julia
-apt1 = SAOImageDS9.accesspoint()             # retrieve current access point
-apt2 = SAOImageDS9.connect("DS9:some_name")  # second access point
-SAOImageDS9.set(arr)                         # send an image to apt2
-SAOImageDS9.connect(apt1);                   # switch to apt1
-SAOImageDS9.set("zoom to", 1.4)              # set zoom in apt1
+apt1 = ds9accesspoint()             # retrieve current access point
+apt2 = ds9connect("DS9:some_name")  # second access point
+ds9set(arr)                         # send an image to apt2
+ds9connect(apt1);                   # switch to apt1
+ds9set("zoom to", 1.4)              # set zoom in apt1
 ```

--- a/docs/src/drawing.md
+++ b/docs/src/drawing.md
@@ -2,15 +2,14 @@
 
 `SAOImageDS9` can be used to quickly draw or display things in SAOImage/DS9.
 
-For instance, assuming `img` is a 2-dimensional Julia array, to display `img`
-as an image in SAOImage/DS9, call:
+For instance, assuming `img` is a 2-dimensional Julia array, to display `img` as an image
+in SAOImage/DS9, call:
 
 ```julia
-SAOImageDS9.draw(img; kwds...)
+ds9draw(img; kwds...)
 ```
 
-The main difference with `SAOImageDS9.set(img)` is that a number of keywords
-are supported:
+The main difference with `ds9set(img)` is that a number of keywords are supported:
 
 - Use keyword `frame` to specify the frame number.
 
@@ -21,7 +20,6 @@ are supported:
 
 - Use keywords `min` and/or `max` to specify the scale limits.
 
-The [`SAOImageDS9.draw`](@ref) method can be called with other kinds of
-arguments such as instances (or array or tuple) of `TwoDimensional.Point` to
-draw point(s) or instances of `TwoDimensional.BoundingBox` to draw
-rectangle(s).
+The [`ds9draw`](@ref) method can be called with other kinds of arguments such as instances
+(or array or tuple) of `TwoDimensional.Point` to draw point(s) or instances of
+`TwoDimensional.BoundingBox` to draw rectangle(s).

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -6,36 +6,40 @@
 ```julia
 import SAOImageDS9
 using SAOImageDS9: TupleOf
-SAOImageDS9.connect()
+ds9connect()
 ```
 
-For a 512×861 image `img` with `Float32` pixels, `SAOImageDS9.set(img)` takes
-8.502 ms (28 allocations: 1.30 KiB) while `SAOImageDS9.get(Array)` takes 5.844
-ms (50 allocations: 1.68 MiB).
+For a 512×861 image `img` with `Float32` pixels, `ds9set(img)` takes 8.502 ms (28
+allocations: 1.30 KiB) while `ds9get(Array)` takes 5.844 ms (50 allocations: 1.68 MiB).
 
 
 Query parameters of the image displayed in the current DS9 frame:
+
 ```julia
-SAOImageDS9.get(Int, "fits width")         # get the width of the image
-SAOImageDS9.get(Int, "fits height")        # get the height of the image
-SAOImageDS9.get(Int, "fits depth")         # get the depth of the image
-SAOImageDS9.get(Int, "fits bitpix")        # get the bits per pixel of the image
-SAOImageDS9.get(TupleOf{Int}, "fits size") # get the dimensions of the image
+ds9get(Int, "fits width")         # get the width of the image
+ds9get(Int, "fits height")        # get the height of the image
+ds9get(Int, "fits depth")         # get the depth of the image
+ds9get(Int, "fits bitpix")        # get the bits per pixel of the image
+ds9get(Vector{Int}, "fits size")  # get the dimensions of the image
 ```
-The dimensions are ordered as `width`, `height` and `depth`.
+
+Compared to a regular Julia's `Array`, SAOImage/DS9 dimensions are ordered as `width`,
+`height`, and `depth`.
 
 To retrieve or set the dimensions of the display window:
+
 ```julia
-SAOImageDS9.get(Int, "width")    # get the width of the image display window
-SAOImageDS9.get(Int, "height")   # get the height of the image display window
-SAOImageDS9.set("width", n)      # set the width of the image display window
-SAOImageDS9.set("height", n)     # set the height of the image display window
+ds9get(Int, "width")   # get the width of the image display window
+ds9get(Int, "height")  # get the height of the image display window
+ds9set("width", npix)   # set the width of the image display window
+ds9set("height", npix)  # set the height of the image display window
 ```
 
 Display an image and set the scale limits:
+
 ```julia
-SAOImageDS9.set(img)
-SAOImageDS9.set("scale limits", 0, maximum(img))
+ds9set(img)
+ds9set("scale limits", 0, maximum(img))
 ```
 
 ## Frame settings
@@ -43,62 +47,62 @@ SAOImageDS9.set("scale limits", 0, maximum(img))
 ### Set frame settings
 
 ```julia
-SAOImageDS9.set("frame center")       # center current frame
-SAOImageDS9.set("frame center",1)     # center 'Frame1'
-SAOImageDS9.set("frame center all")   # center all frames
-SAOImageDS9.set("frame clear")        # clear current frame
-SAOImageDS9.set("frame new")          # create new frame
-SAOImageDS9.set("frame new rgb")      # create new rgb frame
-SAOImageDS9.set("frame delete")       # delete current frame
-SAOImageDS9.set("frame reset")        # reset current frame
-SAOImageDS9.set("frame refresh")      # refresh current frame
-SAOImageDS9.set("frame hide")         # hide current frame
-SAOImageDS9.set("frame show",1)       # show frame 'Frame1'
-SAOImageDS9.set("frame move first")   # move frame to first in order
-SAOImageDS9.set("frame move back")    # move frame back in order
-SAOImageDS9.set("frame move forward") # move frame forward in order
-SAOImageDS9.set("frame move last")    # move frame to last in order
-SAOImageDS9.set("frame first")        # goto first frame
-SAOImageDS9.set("frame prev")         # goto prev frame
-SAOImageDS9.set("frame next")         # goto next frame
-SAOImageDS9.set("frame last")         # goto last frame
-SAOImageDS9.set("frame frameno 4")    # goto frame 'Frame4',create if needed
-SAOImageDS9.set("frame", 3)           # goto frame 'Frame3',create if needed
-SAOImageDS9.set("frame match wcs")
-SAOImageDS9.set("frame lock wcs")
+ds9set("frame center")       # center current frame
+ds9set("frame center",1)     # center 'Frame1'
+ds9set("frame center all")   # center all frames
+ds9set("frame clear")        # clear current frame
+ds9set("frame new")          # create new frame
+ds9set("frame new rgb")      # create new rgb frame
+ds9set("frame delete")       # delete current frame
+ds9set("frame reset")        # reset current frame
+ds9set("frame refresh")      # refresh current frame
+ds9set("frame hide")         # hide current frame
+ds9set("frame show",1)       # show frame 'Frame1'
+ds9set("frame move first")   # move frame to first in order
+ds9set("frame move back")    # move frame back in order
+ds9set("frame move forward") # move frame forward in order
+ds9set("frame move last")    # move frame to last in order
+ds9set("frame first")        # goto first frame
+ds9set("frame prev")         # goto prev frame
+ds9set("frame next")         # goto next frame
+ds9set("frame last")         # goto last frame
+ds9set("frame frameno 4")    # goto frame 'Frame4',create if needed
+ds9set("frame", 3)           # goto frame 'Frame3',create if needed
+ds9set("frame match wcs")
+ds9set("frame lock wcs")
 ```
 
 ### Get frame settings
 
 ```julia
-SAOImageDS9.get(Int, "frame")            # returns the id of the current frame
-SAOImageDS9.get(Int, "frame frameno")    # returns the id of the current frame
-SAOImageDS9.get(TupleOf{Int}, "frame all")    # returns the id of all frames
-SAOImageDS9.get(TupleOf{Int}, "frame active") # returns the id of all active frames
-SAOImageDS9.get(String, "frame lock")
-SAOImageDS9.get(Bool, "frame has amplifier")
-SAOImageDS9.get(Bool, "frame has datamin")
-SAOImageDS9.get(Bool, "frame has datasec")
-SAOImageDS9.get(Bool, "frame has detector")
-SAOImageDS9.get(Bool, "frame has grid")
-SAOImageDS9.get(Bool, "frame has iis")
-SAOImageDS9.get(Bool, "frame has irafmin")
-SAOImageDS9.get(Bool, "frame has physical")
-SAOImageDS9.get(Bool, "frame has smooth")
-SAOImageDS9.get(Bool, "frame has contour")
-SAOImageDS9.get(Bool, "frame has contour aux")
-SAOImageDS9.get(Bool, "frame has fits")
-SAOImageDS9.get(Bool, "frame has fits bin")
-SAOImageDS9.get(Bool, "frame has fits cube")
-SAOImageDS9.get(Bool, "frame has fits mosaic")
-SAOImageDS9.get(Bool, "frame has marker highlite")
-SAOImageDS9.get(Bool, "frame has marker paste")
-SAOImageDS9.get(Bool, "frame has marker select")
-SAOImageDS9.get(Bool, "frame has marker undo")
-SAOImageDS9.get(Bool, "frame has system physical")
-SAOImageDS9.get(Bool, "frame has wcs wcsa")
-SAOImageDS9.get(Bool, "frame has wcs equatorial wcsa")
-SAOImageDS9.get(Bool, "frame has wcs linear wcsa")
+ds9get(Int, "frame")                # returns the id of the current frame
+ds9get(Int, "frame frameno")        # returns the id of the current frame
+ds9get(Vector{Int}, "frame all")    # returns the id of all frames
+ds9get(Vector{Int}, "frame active") # returns the id of all active frames
+ds9get(String, "frame lock")
+ds9get(Bool, "frame has amplifier")
+ds9get(Bool, "frame has datamin")
+ds9get(Bool, "frame has datasec")
+ds9get(Bool, "frame has detector")
+ds9get(Bool, "frame has grid")
+ds9get(Bool, "frame has iis")
+ds9get(Bool, "frame has irafmin")
+ds9get(Bool, "frame has physical")
+ds9get(Bool, "frame has smooth")
+ds9get(Bool, "frame has contour")
+ds9get(Bool, "frame has contour aux")
+ds9get(Bool, "frame has fits")
+ds9get(Bool, "frame has fits bin")
+ds9get(Bool, "frame has fits cube")
+ds9get(Bool, "frame has fits mosaic")
+ds9get(Bool, "frame has marker highlite")
+ds9get(Bool, "frame has marker paste")
+ds9get(Bool, "frame has marker select")
+ds9get(Bool, "frame has marker undo")
+ds9get(Bool, "frame has system physical")
+ds9get(Bool, "frame has wcs wcsa")
+ds9get(Bool, "frame has wcs equatorial wcsa")
+ds9get(Bool, "frame has wcs linear wcsa")
 ```
 
 
@@ -107,58 +111,63 @@ SAOImageDS9.get(Bool, "frame has wcs linear wcsa")
 Get *about* string:
 
 ```julia
-SAOImageDS9.get(String, "about")
+ds9get(String, "about")
 ```
 
-Get version number:
+Get version number, one of:
 
 ```julia
-SAOImageDS9.get(VersionNumber, "version")
+ds9get(Tuple{String,VersionNumber}, "version")[2]
+ds9get(VersionNumber)
 ```
 
-Exit SAOImage/DS9:
+Exit SAOImage/DS9, one of:
 
 ```julia
-SAOImageDS9.set("exit")
+ds9set("exit")
+ds9set("quit")
+ds9quit()
 ```
+
+However, only the last one close the connection.
 
 Is SAOImage/DS9 iconified?
 
 ```julia
-SAOImageDS9.get(Bool, "iconify")
+ds9get(Bool, "iconify")
 ```
 
 (De)iconify SAOImage/DS9:
 
 ```julia
-SAOImageDS9.set("iconify", bool)
+ds9set("iconify", bool)
 ```
 
 ```julia
-SAOImageDS9.set("lower")
-SAOImageDS9.set("raise") # can be used to de-iconify
+ds9set("lower")
+ds9set("raise") # can be used to de-iconify
 ```
 
 Get/set zoom level:
 ```julia
-SAOImageDS9.get(Float64, "zoom")  # get current zoom level
-SAOImageDS9.set("zoom", value)
-SAOImageDS9.set("zoom to", value)
-SAOImageDS9.set("zoom to fit")
+ds9get(Float64, "zoom")  # get current zoom level
+ds9set("zoom", value)
+ds9set("zoom to", value)
+ds9set("zoom to fit")
 ```
 
 Rotation:
 ```julia
-SAOImageDS9.get(Float64, "rotate")
-SAOImageDS9.set("rotate", value)
-SAOImageDS9.set("rotate to", value)
-SAOImageDS9.set("rotate open")
-SAOImageDS9.set("rotate close")
+ds9get(Float64, "rotate")
+ds9set("rotate", value)
+ds9set("rotate to", value)
+ds9set("rotate open")
+ds9set("rotate close")
 ```
 
 ```julia
-SAOImageDS9.get(String, "orient")
-SAOImageDS9.set("orient", value)
+ds9get(String, "orient")
+ds9set("orient", value)
 ```
 
 ```julia
@@ -167,6 +176,6 @@ SAOImageDS9.set("orient", value)
 iexam(args...; event::Union{AbstractString,Symbol}=:button) =
     get_words("iexam", event, args...)
 
-SAOImageDS9.get(Int, :threads)  # get threads
-SAOImageDS9.set("threads", n)
+ds9get(Int, :threads)  # get threads
+ds9set("threads", n)
 ```

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -1,17 +1,8 @@
 # Installation
 
-To use this package, the SAOImage/DS9 program and the
-[XPA](https://github.com/ericmandel/xpa) dynamic library and headers must be
-installed on your computer.  If this is not the case, they are available for
-different operating systems.  For example, on Debian or Ubuntu-like Linux
-system, you can call `apt` (or `apt-get` on older systems) from the command line:
+`SAOImageDS9` can be can be installed by Julia's package manager. In the Julia REPL, press
+`]` to drop into package mode, then run:
 
-```sh
-sudo apt install saods9 libxpa-dev
-```
-
-`SAOImageDS9` can be can be installed by Julia's package manager. In the Julia
-REPL, press `]` to drop into package mode, then run
 ```julia-repl
 pkg> add SAOImageDS9
 ```
@@ -24,10 +15,6 @@ Pkg.add("SAOImageDS9")
 # or
 Pkg.add(PackageSpec(name="SAOImageDS9", rev="master"))
 ```
-
-See [XPA.jl site](https://github.com/JuliaAstro/XPA.jl) for instructions about
-how to install this package if the installation of `SAOImageDS9` fails to
-properly install this required package.
 
 To upgrade the `SAOImageDS9` package:
 

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -3,22 +3,34 @@
 ## Requests to SAOImage/DS9
 
 ```@docs
-SAOImageDS9.get
-SAOImageDS9.set
+ds9get
+ds9set
 ```
 
 ## Connection
 
 ```@docs
-SAOImageDS9.connect
-SAOImageDS9.accesspoint
+ds9accesspoint
+ds9connect
+ds9disconnect
+```
+
+## Starting/quitting SAOImage/DS9 application
+
+```@docs
+ds9launch
+ds9quit
 ```
 
 
-## Drawing
+## Miscellaneaous
 
 ```@docs
-SAOImageDS9.draw
+ds9cursor
+ds9draw
+ds9message
+ds9getregions
+ds9wcs
 ```
 
 ## Utilities

--- a/docs/src/requests.md
+++ b/docs/src/requests.md
@@ -1,8 +1,8 @@
 # SAOImage/DS9 requests
 
-There are two kinds of requests: **get** requests to retrieve some information
-or data from SAOImage/DS9 and **set** requests to send some data to
-SAOImage/DS9 or to set some of its parameters.
+There are two kinds of requests: **get** requests to retrieve some information or data
+from SAOImage/DS9 and **set** requests to send some data to SAOImage/DS9 or to set some of
+its parameters.
 
 
 ## Set requests
@@ -11,37 +11,36 @@ The general syntax to perform a **set** request to the current SAOImage/DS9
 access point is:
 
 ```julia
-SAOImageDS9.set(args...; data=nothing)
+ds9set(args...; data=nothing)
 ```
 
-where `args...` are any number of arguments which will be automatically
-converted in a string where the arguments are separated by spaces.  The keyword
-`data` may be used to specify the data to send with the request, it may be
-`nothing` (the default) or a Julia array.  For instance, the following 3 calls
-will set the current zoom to be equal to 3.7:
+where `args...` are any number of arguments which will be automatically converted into a
+string where the elements of `args...` are separated by a single space. The `data` keyword
+may be used to specify the data to send with the request, it may be `nothing` (the
+default) or a Julia array. For instance, the following 3 calls will set the current zoom
+to be equal to 3.7:
 
 ```julia
-SAOImageDS9.set(:zoom,:to,3.7)
-SAOImageDS9.set("zoom to",3.7)
-SAOImageDS9.set("zoom to 3.7")
+ds9set(:zoom, :to, 3.7)
+ds9set("zoom to", 3.7)
+ds9set("zoom to 3.7")
 ```
 
-where the last line shows the string which is effectively sent to SAOImage/DS9
-via the `XPA.set` method in the 3 above cases.
+where the last line shows the string which is effectively sent to SAOImage/DS9 via the
+`XPA.set` method in the 3 above cases.
 
-As a special case, `args...` can be a single array to send to SAOImage/DS9 for
-being displayed:
+As a special case, `args...` can be a single array to send to SAOImage/DS9 for being
+displayed:
 
 ```julia
-SAOImageDS9.set(arr)
+ds9set(arr)
 ```
 
-where `arr` is a 2D or 3D Julia array.  SAOImage/DS9 will display the values of
-`arr` as an image (if `arr` is a 2D array) or a sequence of images (if `arr` is
-a 3D array) in the currently selected frame with the current scale parameters,
-zoom, orientation, rotation, etc.  Keyword `order` can be used to specify the
-byte ordering.  Keyword `new` can be set true to display the image in a new
-SAOImage/DS9 frame.
+where `arr` is a 2D or 3D Julia array. SAOImage/DS9 will display the values of `arr` as an
+image (if `arr` is a 2D array) or a sequence of images (if `arr` is a 3D array) in the
+currently selected frame with the current scale parameters, zoom, orientation, rotation,
+etc. Keyword `order` can be used to specify the byte ordering. Keyword `new` can be set
+true to display the image in a new SAOImage/DS9 frame. FIXME
 
 
 ## Get requests
@@ -49,16 +48,16 @@ SAOImage/DS9 frame.
 To perform a **get** request, the general syntax is:
 
 ```julia
-SAOImageDS9.get([T, [dims,]] args...)
+ds9get([T, [dims,]] args...)
 ```
 
-where the `args...` arguments are treated as for the `SAOImageDS9.set` method
+where the `args...` arguments are treated as for the `ds9set` method
 (that is converted into a single text string with separating spaces).  Optional
 arguments `T` and `dims` are to specify the type of the expected result and,
 possibly, its list of dimensions.
 
 If neither `T` nor `dims` are specified, the result of the
-`SAOImageDS9.get(args...)` call is an instance of `XPA.Reply` (see
+`ds9get(args...)` call is an instance of `XPA.Reply` (see
 documentation about XPA.jl package for how to deal with the contents of such an
 instance).
 
@@ -66,15 +65,15 @@ The following methods can be used to issue a **get** request to the current DS9
 access point depending on the expected type of result:
 
 ```julia
-SAOImageDS9.get(Vector{UInt8}, args...)         -> buf
-SAOImageDS9.get(String, args...)                -> str
-SAOImageDS9.get(Vector{String}, args...;
+ds9get(Vector{UInt8}, args...)         -> buf
+ds9get(String, args...)                -> str
+ds9get(Vector{String}, args...;
                 delim=isspace, keepempty=false) -> arr
-SAOImageDS9.get(Tuple{Vararg{String}}, args...;
+ds9get(Tuple{Vararg{String}}, args...;
                 delim=isspace, keepempty=false) -> tup
 ```
 
-where `args...` are treated as for the `SAOImageDS9.set` method.  The returned
+where `args...` are treated as for the `ds9set` method.  The returned
 values are respectively a vector of bytes, a single string (with the last
 end-of-line removed if any), an array of strings (one for each line of the
 result and empty line removed unless keyword `keepempty` is set `true`), or an
@@ -84,8 +83,8 @@ If a single scalar integer or floating point is expected, two methods are
 available:
 
 ```julia
-SAOImageDS9.get(Int, args...)    -> scalar
-SAOImageDS9.get(Float, args...)  -> scalar
+ds9get(Int, args...)    -> scalar
+ds9get(Float, args...)  -> scalar
 ```
 
 which return respectively an `Int` and a `Float64`.
@@ -93,7 +92,7 @@ which return respectively an `Int` and a `Float64`.
 To retrieve the array displayed by the current SAOImage/DS9 frame, do:
 
 ```julia
-arr = SAOImageDS9.get(Array);
+arr = ds9get(Array);
 ```
 
 Keyword `order` can be used to specify the byte ordering.

--- a/docs/src/starting.md
+++ b/docs/src/starting.md
@@ -1,43 +1,25 @@
 # Starting
 
-
-
 To use `SAOImageDS9` package, type:
 
 ```julia
 using SAOImageDS9
 ```
 
-will import the symbol `DS9` which can be used to prefix all methods
-available in `SAOImageDS9` instead of the full package name which can be a bit
-tedious in interactive sessions.  If you prefer another prefix, say `sao`,
-you can do:
+will import the public symbols of the package (all prefixed by `ds9`).
 
-```julia
-import SAOImageDS9
-const sao = SAOImageDS9
-```
-
-or (provided your Julia version is at least 1.6):
-
-```julia
-import SAOImageDS9 as sao
-```
-
-You may also just `import SAOImageDS9` and keep the `SAOImageDS9` prefix.
-Throughout all the remaining documentation, no shortcut is assumed.
-
-You may call the [`SAOImageDS9.connect`](@ref) method to specify the access
-point to a given running SAOImage/DS9 application.  If no given access point is
-specified, `SAOImageDS9` will automatically attempts to connect to the first
-access point matching `"DS9.*"` when a command is sent to SAOImage/DS9.  The
-method [`SAOImageDS9.accesspoint()`](@ref) yields the name of the current
-access point to SAOImage/DS9, or an empty string if none has been chosen.
+You may call the [`ds9connect`](@ref) method to specify the access point to a given
+running SAOImage/DS9 application. If no given access point is specified,
+[`ds9connect()`](@ref) will automatically attempt to connect to the first access point
+matching `"DS9.*"` when a command is sent to SAOImage/DS9. The method
+[`ds9accesspoint()`](@ref) yields the name of the current access point to SAOImage/DS9, or
+an access-point with an empty address has been chosen or if [`ds9disconnect`](@ref) has
+been called.
 
 To check the connection to SAOImage/DS9, you can type:
 
 ```julia
-SAOImageDS9.get(VersionNumber)
+ds9get(VersionNumber)
 ```
 
 which should yield the version of the SAOImage/DS9 to which you are connected.

--- a/src/SAOImageDS9.jl
+++ b/src/SAOImageDS9.jl
@@ -869,34 +869,6 @@ function ds9cursor(apt::AccessPoint=default_apt();
     end
 end
 
-function cube(; apt=default_apt())
-    get_and_parse(Int, apt, "cube")
-end
-function cube(z::Integer; apt=default_apt())
-    XPA.set(apt, "cube $z")
-end
-
-function cube_interval(; apt=default_apt())
-    get_and_parse(Float64, apt, "cube interval")
-end
-function cube_interval(dt::Real; apt=default_apt())
-    XPA.set(apt, "cube interval $dt")
-end
-
-function cube(; apt=_apt())
-    get_and_parse(Int, apt, "cube")
-end
-function cube(z::Integer; apt=_apt())
-    XPA.set(apt, "cube $z")
-end
-
-function cube_interval(; apt=_apt())
-    get_and_parse(Float64, apt, "cube interval")
-end
-function cube_interval(dt::Real; apt=_apt())
-    XPA.set(apt, "cube interval $dt")
-end
-
 #------------------------------------------------------------------------------
 # LIMITS
 


### PR DESCRIPTION
There were no real needs for having 2 methods. This change simplifies the API and recuce the number of breaking changes.